### PR TITLE
Added possibility to optional fire events for each char which gets typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,27 @@ It may be helpful to play around with these props in the [interactive demo](http
 
   Emitted everytime VueTyper finishes typing a string.
 
+#### `typed-char`
+- **Event data**:
+  - `String` lastTypedChar
+- **Usage**:
+  ```html
+  <vue-typer text='watermelon' @typed-char='onTypedChar'></vue-typer>
+  ```
+  ```javascript
+  {
+    ...
+    methods: {
+      onTypedChar: function(lastTypedChar) {
+        // handle last typed char
+      }
+    }
+  }
+  ```
+
+  Emitted after each char which was typed.
+
+
 #### `erased`
 - **Event data**:
   - `String` erasedString

--- a/src/vue-typer/components/VueTyper.vue
+++ b/src/vue-typer/components/VueTyper.vue
@@ -128,7 +128,14 @@ export default {
     /**
      * Caret animation style. See Caret.vue.
      */
-    caretAnimation: String
+    caretAnimation: String,
+    /**
+     * inform parent component when a char was rendered
+     */
+    emitOnCharTyping: {
+      type: Boolean,
+      default: false
+    }
   },
   data() {
     return {
@@ -265,6 +272,9 @@ export default {
     typeStep() {
       if (!this.isDoneTyping) {
         this.shiftCaret(1)
+        if (this.emitOnCharTyping) {
+          this.$emit('chartyped', this.currentText.charAt(this.currentTextIndex))
+        }
       }
 
       if (this.isDoneTyping) {

--- a/src/vue-typer/components/VueTyper.vue
+++ b/src/vue-typer/components/VueTyper.vue
@@ -129,13 +129,6 @@ export default {
      * Caret animation style. See Caret.vue.
      */
     caretAnimation: String,
-    /**
-     * inform parent component when a char was rendered
-     */
-    emitOnCharTyping: {
-      type: Boolean,
-      default: false
-    }
   },
   data() {
     return {
@@ -272,9 +265,7 @@ export default {
     typeStep() {
       if (!this.isDoneTyping) {
         this.shiftCaret(1)
-        if (this.emitOnCharTyping) {
-          this.$emit('chartyped', this.currentText.charAt(this.currentTextIndex))
-        }
+        this.$emit('typed-char', this.currentText.charAt(this.currentTextIndex))
       }
 
       if (this.isDoneTyping) {


### PR DESCRIPTION
There is a new property emitOnCharTyping, if this property is set to true an event is emited after each rendered char. The default value for emitOnCharTyping is false.
Configuration:
<vue-typer :emitOnCharTyped='true' text='hallo'/>

It is possible to listen to these event like that:

`<vue-typer :emitOnCharTyped='true' @chartyped="onCharTyped" text='hallo'/>`

`function onCharTyped(lastCharTyped){}`

The function used for listening gets called with one parameter which is the last char which was rendered.

This can be handy if special effects should be executed after a char was rendered.
I used this to create a typing sound effect and used for each character a different typing sound :)